### PR TITLE
Use Newton's method to refine results of polynomial solving

### DIFF
--- a/diagrams-solve.cabal
+++ b/diagrams-solve.cabal
@@ -32,6 +32,7 @@ test-suite tests
   main-is: Test.hs
   -- other-modules: Instances
   hs-source-dirs: tests
+  default-language:    Haskell2010
   build-depends:       base >= 4.2 && < 4.10,
                        tasty >= 0.10 && < 0.12,
                        tasty-hunit >= 0.9.2 && < 0.10,

--- a/src/Diagrams/Solve/Polynomial.hs
+++ b/src/Diagrams/Solve/Polynomial.hs
@@ -70,10 +70,6 @@ quadForm a b c
  where d = b^2 - 4*a*c
        q = -1/2*(b + signum b * sqrt d)
 
-_quadForm_prop :: Double -> Double -> Double -> Bool
-_quadForm_prop a b c = all (aboutZero' 1e-10 . eval) (quadForm a b c)
-  where eval x = a*x^2 + b*x + c
-
 ------------------------------------------------------------
 -- Cubic formula
 ------------------------------------------------------------
@@ -120,19 +116,6 @@ cubForm' toler a b c d
 cubForm :: (Floating d, Ord d) => d -> d -> d -> d -> [d]
 cubForm = cubForm' 1e-10
 
-_cubForm_prop :: Double -> Double -> Double -> Double -> Bool
-_cubForm_prop a b c d = all (aboutZero' 1e-5 . eval) (cubForm a b c d)
-  where eval x = a*x^3 + b*x^2 + c*x + d
-           -- Basically, however large you set the tolerance it seems
-           -- that quickcheck can always come up with examples where
-           -- the returned solutions evaluate to something near zero
-           -- but larger than the tolerance (but it takes it more
-           -- tries the larger you set the tolerance). Wonder if this
-           -- is an inherent limitation or (more likely) a problem
-           -- with numerical stability.  If this turns out to be an
-           -- issue in practice we could, say, use the solutions
-           -- generated here as very good guesses to a numerical
-           -- solver which can give us a more precise answer?
 
 ------------------------------------------------------------
 -- Quartic formula
@@ -184,7 +167,3 @@ quartForm' toler c4 c3 c2 c1 c0
 quartForm :: (Floating d, Ord d) => d -> d -> d -> d -> d -> [d]
 quartForm = quartForm' 1e-10
 
-_quartForm_prop :: Double -> Double -> Double -> Double -> Double -> Bool
-_quartForm_prop a b c d e = all (aboutZero' 1e-5 . eval) (quartForm a b c d e)
-  where eval x = a*x^4 + b*x^3 + c*x^2 + d*x + e
-           -- Same note about tolerance as for cubic

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,21 +1,29 @@
 module Main where
 
-import Diagrams.Solve.Polynomial
+import           Diagrams.Solve.Polynomial
 
-import Test.Tasty (defaultMain, testGroup, TestTree)
+import           Test.Tasty                (TestTree, defaultMain, localOption,
+                                            testGroup)
 import           Test.Tasty.QuickCheck
 
 tests :: TestTree
-tests = testGroup "Solve" [
-         testProperty "solutions found satisfy quadratic equation" $
-         \a b c -> let sat x =  a * x * x + b * x + c =~ 0 in all sat (quadForm a b c)
--- could verify number of solutions, but we would just duplicate the function definition
-        , testProperty "solutions found satisfy cubic equation" $
-         \a b c d -> let sat x =  a * x * x * x + b * x * x + c * x + d =~ (0 :: Double) in all sat (cubForm a b c d)
-        ]
+tests
+  = localOption (QuickCheckTests 1000) $
+    testGroup "Solve"
+  [ testProperty "solutions found satisfy quadratic equation" $
+    \a b c -> all (\x -> evalPoly [c,b,a] x =~ 0) (quadForm a b c)
+
+  , testProperty "solutions found satisfy cubic equation" $
+    \a b c d -> all (\x -> evalPoly [d,c,b,a] x =~ 0) (cubForm a b c d)
+
+  , testProperty "solutions found satisfy quartic equation" $
+    \a b c d e ->
+      let sat x = a*x^4 + b*x^3 + c*x^2 + d*x + e =~ (0 :: Double)
+      in  all sat (quartForm a b c d e)
+  ]
 
 (=~) :: Double -> Double -> Bool
-(=~) a b = abs (a - b) < 0.001
+(=~) a b = abs (a - b) < 1e-5
 infix 4 =~
 
 main :: IO ()


### PR DESCRIPTION
This seems to improve solution accuracy a good bit, i.e. the QC tests take a lot longer to fail.  `cubForm` sometimes even makes it through 1000 tests without failing.

This has uncovered some deeper bugs, e.g. `quartForm` sometimes returns NaNs.

I haven't benchmarked to see how much this impacts performance.
