### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/diagrams-solve.cabal
+++ b/diagrams-solve.cabal
@@ -23,7 +23,7 @@ Source-repository head
 library
   exposed-modules:     Diagrams.Solve.Polynomial,
                        Diagrams.Solve.Tridiagonal
-  build-depends:       base >=4.5 && < 4.10
+  build-depends:       base >=4.5 && < 4.11
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -32,7 +32,7 @@ test-suite tests
   main-is: Test.hs
   -- other-modules: Instances
   hs-source-dirs: tests
-  build-depends:       base >= 4.2 && < 4.10,
+  build-depends:       base >= 4.2 && < 4.11,
                        tasty >= 0.10 && < 0.12,
                        tasty-hunit >= 0.9.2 && < 0.10,
                        tasty-quickcheck >= 0.8 && < 0.9,


### PR DESCRIPTION
GHC 8.2 ships with base-4.10.
This still builds and passes tests after the bump.