### PR TITLE
Solve tolerance issue with quartForm

### DIFF
--- a/src/Diagrams/Solve/Polynomial.hs
+++ b/src/Diagrams/Solve/Polynomial.hs
@@ -169,7 +169,7 @@ quartForm' toler c4 c3 c2 c1 c0
       -- | roots of the reduced quartic
       roots | aboutZero' toler r =
                 0 : cubForm 1 0 p q   -- no constant term: y(y^3 + py + q) = 0
-            | u < 0 || v < 0 = []     -- no real solutions due to square root
+            | u < -toler || v < -toler = []     -- no real solutions due to square root
             | otherwise      = s1++s2 -- solutions of the quadratics
 
       -- solve the resolvent cubic - only one solution is needed

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Data.List (sort)
 import Diagrams.Solve.Polynomial
 
 import Test.Tasty (defaultMain, testGroup, TestTree)
@@ -12,6 +13,13 @@ tests = testGroup "Solve" [
 -- could verify number of solutions, but we would just duplicate the function definition
         , testProperty "solutions found satisfy cubic equation" $
          \a b c d -> let sat x =  a * x * x * x + b * x * x + c * x + d =~ (0 :: Double) in all sat (cubForm a b c d)
+
+-- some specific examples and regression tests
+        , testGroup "Solve specific examples" [
+            testProperty "1 * u^4 + -240 * u^3 + 25449 * u^2 + -1325880 * u + 26471900.25 = 0" $
+                let [r1, r2] = sort $ quartForm 1 (-240) 25449 (-1325880) 26471900.25 in
+                r1 =~ 50.6451 && r2 =~ 69.3549
+            ]
         ]
 
 (=~) :: Double -> Double -> Bool


### PR DESCRIPTION
I ported Polynomial.hs to Elm so I could use it for ray tracing a torus in a
browser game I was working on.  I noticed several artefacts in the result and
traced it down to `quartForm` not returning any roots in a few cases.

The polynomial I used for debugging was:

    1 * u^4 + -240 * u^3 + 25449 * u^2 + -1325880 * u + 26471900.25 = 0

Which has two roots according to Wolfram Alpha:

<https://www.wolframalpha.com/input/?i=1+*+u%5E4+%2B+-240+*+u%5E3+%2B+25449+*+u%5E2+%2B+-1325880+*+u+++%2B+26471900.25>

This patch fixes this specific issue and a few other artefacts I saw.  It did
not introduce any other glitches or artefacts into the ray tracer that I'm aware
of.