### PR TITLE
Fix tolerance issue in cubForm

### DIFF
--- a/src/Diagrams/Solve/Polynomial.hs
+++ b/src/Diagrams/Solve/Polynomial.hs
@@ -107,8 +107,7 @@ cubForm' toler a b c d
  where delta  = 18*a*b*c*d - 4*b^3*d + b^2*c^2 - 4*a*c^3 - 27*a^2*d^2
        disc   = 3*a*c - b^2
        qq     = sqrt(-27*(a^2)*delta)
-       qq'    | aboutZero' toler disc = maximumBy (comparing (abs . (+xx))) [qq, -qq]
-              | otherwise = qq
+       qq'    = if abs (xx + qq) > abs (xx - qq) then qq else -qq
        cc     = cubert (1/2*(qq' + xx))
        xx     = 2*b^3 - 9*a*b*c + 27*a^2*d
        p      = disc/(3*a^2)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -16,7 +16,11 @@ tests = testGroup "Solve" [
 
 -- some specific examples and regression tests
         , testGroup "Solve specific examples" [
-            testProperty "1 * u^4 + -240 * u^3 + 25449 * u^2 + -1325880 * u + 26471900.25 = 0" $
+            testProperty "1 * x^3 + -886.7970773009183 * x^2 + 262148.4783430062 * x + -264000817.775054 = 0" $
+                let [r] = cubForm 1 (-886.7970773009183) 262148.4783430062 (-264000817.775054) in
+                r =~ 915.4538593912
+
+          , testProperty "1 * u^4 + -240 * u^3 + 25449 * u^2 + -1325880 * u + 26471900.25 = 0" $
                 let [r1, r2] = sort $ quartForm 1 (-240) 25449 (-1325880) 26471900.25 in
                 r1 =~ 50.6451 && r2 =~ 69.3549
             ]


### PR DESCRIPTION
Hi Brent, I was seeing another (smaller) artefact in the code that produced #7
and and your quick response prompted me to look into this further.

I thought there was another issue in `quartForm`, but after tracing it down a
lot further, it turned out that the actual problem was in `cubForm`.  I got
the resolvent cubic.  This was:

    1 * x^3 + -886.7970773009183 * x^2 + 262148.4783430062 * x + -264000817.775054

Which [wolfram alpha solves](https://www.wolframalpha.com/input/?i=1+*+x%5E3+%2B+-886.7970773009183+*+x%5E2+%2B+262148.4783430062+*+x+%2B+-264000817.775054)
as 915.4538593912 but the code was returning 911.5670525972223 -- that's too
big a difference to be the result of floating point precision.

It turns out that `disc` can get extremely small but the sign of `qq` will still
be meaningful.  Simplifying the branches there got me the expected result.